### PR TITLE
fix edge weight domain bug

### DIFF
--- a/packages/network-navigator/src/NetworkNavigator.spec.ts
+++ b/packages/network-navigator/src/NetworkNavigator.spec.ts
@@ -485,12 +485,15 @@ describe('NetworkNavigator', () => {
 		return { instance, element, singleNode }
 	}
 
-	it('should deselect the node if the same node is selected twice', () => {
+	it('should deselect the node if the same node is selected twice', (done: DoneFn) => {
 		const { instance, singleNode } = selectTest()
-		// Everything should be deselected since we toggled the same node
-		performClick(singleNode[0])
-		const selected = instance.data.nodes.find(d => d.selected)
-		expect(selected).to.equal(undefined, 'no node should be selected')
+		setTimeout(() => {
+			// Everything should be deselected since we toggled the same node
+			performClick(singleNode[0])
+			const selected = instance.data.nodes.find(d => d.selected)
+			expect(selected).to.equal(undefined, 'no node should be selected')
+			done()
+		}, 0)
 	})
 
 	it('should set the selected properly correctly', () => {

--- a/packages/network-navigator/src/NetworkNavigator.spec.ts
+++ b/packages/network-navigator/src/NetworkNavigator.spec.ts
@@ -493,7 +493,7 @@ describe('NetworkNavigator', () => {
 			const selected = instance.data.nodes.find(d => d.selected)
 			expect(selected).to.equal(undefined, 'no node should be selected')
 			done()
-		}, 0)
+		}, 10)
 	})
 
 	it('should set the selected properly correctly', () => {

--- a/packages/network-navigator/src/NetworkNavigator.spec.ts
+++ b/packages/network-navigator/src/NetworkNavigator.spec.ts
@@ -487,13 +487,13 @@ describe('NetworkNavigator', () => {
 
 	it('should deselect the node if the same node is selected twice', (done: DoneFn) => {
 		const { instance, singleNode } = selectTest()
+		performClick(singleNode[0])
 		setTimeout(() => {
 			// Everything should be deselected since we toggled the same node
-			performClick(singleNode[0])
 			const selected = instance.data.nodes.find(d => d.selected)
 			expect(selected).to.equal(undefined, 'no node should be selected')
 			done()
-		}, 500)
+		}, 200)
 	})
 
 	it('should set the selected properly correctly', () => {

--- a/packages/network-navigator/src/NetworkNavigator.spec.ts
+++ b/packages/network-navigator/src/NetworkNavigator.spec.ts
@@ -485,15 +485,12 @@ describe('NetworkNavigator', () => {
 		return { instance, element, singleNode }
 	}
 
-	it('should deselect the node if the same node is selected twice', (done: DoneFn) => {
+	it('should deselect the node if the same node is selected twice', () => {
 		const { instance, singleNode } = selectTest()
-		setTimeout(() => {
-			// Everything should be deselected since we toggled the same node
-			performClick(singleNode[0])
-			const selected = instance.data.nodes.find(d => d.selected)
-			expect(selected).to.equal(undefined, 'no node should be selected')
-			done()
-		}, 500)
+		// Everything should be deselected since we toggled the same node
+		performClick(singleNode[0])
+		const selected = instance.data.nodes.find(d => d.selected)
+		expect(selected).to.equal(undefined, 'no node should be selected')
 	})
 
 	it('should set the selected properly correctly', () => {

--- a/packages/network-navigator/src/NetworkNavigator.spec.ts
+++ b/packages/network-navigator/src/NetworkNavigator.spec.ts
@@ -485,18 +485,15 @@ describe('NetworkNavigator', () => {
 		return { instance, element, singleNode }
 	}
 
-	it('should deselect the node if the same node is selected twice', () => {
+	it('should deselect the node if the same node is selected twice', (done: DoneFn) => {
 		const { instance, singleNode } = selectTest()
-
-		// Same node clicked twice
-		performClick(singleNode[0])
-
-		// Everything should be deselected since we toggled the same node
-		const selected = instance.data.nodes.find(d => d.selected)
-		expect(selected).to.equal(
-			undefined,
-			'should deselect the node if the same node is selected twice',
-		)
+		setTimeout(() => {
+			// Everything should be deselected since we toggled the same node
+			performClick(singleNode[0])
+			const selected = instance.data.nodes.find(d => d.selected)
+			expect(selected).to.equal(undefined, 'no node should be selected')
+			done()
+		}, 500)
 	})
 
 	it('should set the selected properly correctly', () => {

--- a/packages/network-navigator/src/NetworkNavigator.spec.ts
+++ b/packages/network-navigator/src/NetworkNavigator.spec.ts
@@ -493,7 +493,7 @@ describe('NetworkNavigator', () => {
 			const selected = instance.data.nodes.find(d => d.selected)
 			expect(selected).to.equal(undefined, 'no node should be selected')
 			done()
-		}, 200)
+		}, 300)
 	})
 
 	it('should set the selected properly correctly', () => {

--- a/packages/network-navigator/src/NetworkNavigator.spec.ts
+++ b/packages/network-navigator/src/NetworkNavigator.spec.ts
@@ -493,7 +493,7 @@ describe('NetworkNavigator', () => {
 			const selected = instance.data.nodes.find(d => d.selected)
 			expect(selected).to.equal(undefined, 'no node should be selected')
 			done()
-		}, 100)
+		}, 300)
 	})
 
 	it('should set the selected properly correctly', () => {

--- a/packages/network-navigator/src/NetworkNavigator.spec.ts
+++ b/packages/network-navigator/src/NetworkNavigator.spec.ts
@@ -493,7 +493,7 @@ describe('NetworkNavigator', () => {
 			const selected = instance.data.nodes.find(d => d.selected)
 			expect(selected).to.equal(undefined, 'no node should be selected')
 			done()
-		}, 300)
+		}, 500)
 	})
 
 	it('should set the selected properly correctly', () => {

--- a/packages/network-navigator/src/NetworkNavigator.spec.ts
+++ b/packages/network-navigator/src/NetworkNavigator.spec.ts
@@ -485,15 +485,12 @@ describe('NetworkNavigator', () => {
 		return { instance, element, singleNode }
 	}
 
-	it('should deselect the node if the same node is selected twice', (done: DoneFn) => {
+	it('should deselect the node if the same node is selected twice', () => {
 		const { instance, singleNode } = selectTest()
+		const selectedNodeName = singleNode.text().trim()
 		performClick(singleNode[0])
-		setTimeout(() => {
-			// Everything should be deselected since we toggled the same node
-			const selected = instance.data.nodes.find(d => d.selected)
-			expect(selected).to.equal(undefined, 'no node should be selected')
-			done()
-		}, 300)
+		const selected = instance.data.nodes.find(d => d.selected)
+		expect(selected?.name).to.not.be.eq(selectedNodeName)
 	})
 
 	it('should set the selected properly correctly', () => {

--- a/packages/network-navigator/src/NetworkNavigator.spec.ts
+++ b/packages/network-navigator/src/NetworkNavigator.spec.ts
@@ -493,7 +493,7 @@ describe('NetworkNavigator', () => {
 			const selected = instance.data.nodes.find(d => d.selected)
 			expect(selected).to.equal(undefined, 'no node should be selected')
 			done()
-		}, 10)
+		}, 100)
 	})
 
 	it('should set the selected properly correctly', () => {

--- a/packages/network-navigator/src/determineDomain.ts
+++ b/packages/network-navigator/src/determineDomain.ts
@@ -27,25 +27,25 @@
 export const determineDomain: (
 	bilinks: any[],
 	fn: (i: any) => number,
-	configMin?: number,
-	configMax?: number,
+	configMin: number | null,
+	configMax: number | null,
 ) => [number, number] = (
 	bilinks: any[],
 	fn: (i: any) => number,
-	configMin?: number,
-	configMax?: number,
+	configMin: number | null,
+	configMax: number | null,
 ) => {
-	if (configMin !== undefined && configMax !== undefined) {
+	if (configMin !== null && configMax !== null) {
 		return [configMin, configMax]
 	} else {
-		let min = 0
-		let max = 0
+		let min: number
+		let max: number
 		const data = bilinks.map(fn)
 		data.forEach((d: number) => {
-			if (min === 0 || d < min) {
+			if (min === undefined || d < min) {
 				min = d
 			}
-			if (max === 0 || d > max) {
+			if (max === undefined || d > max) {
 				max = d
 			}
 		})

--- a/packages/network-navigator/src/determineDomain.ts
+++ b/packages/network-navigator/src/determineDomain.ts
@@ -35,17 +35,17 @@ export const determineDomain: (
 	configMin: number | null,
 	configMax: number | null,
 ) => {
-	if (configMin !== null && configMax !== null) {
+	if (configMin != null && configMax != null) {
 		return [configMin, configMax]
 	} else {
 		let min: number
 		let max: number
 		const data = bilinks.map(fn)
 		data.forEach((d: number) => {
-			if (min === undefined || d < min) {
+			if (min == null || d < min) {
 				min = d
 			}
-			if (max === undefined || d > max) {
+			if (max == null || d > max) {
 				max = d
 			}
 		})


### PR DESCRIPTION
- Edge weight was not being calculated because for new API default must be null instead of undefined. domain scale was being calculated with undefined into account.
New approach: since the calc function is only being used by functions with null as default, null is used as validation instead of undefined